### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A modern, reactive TUI framework for .NET 8 with declarative components, reactiv
 
 ## Repository structure
 - `src/` — library projects (packable)
+  - `Andy.Tui` (umbrella meta-package)
   - `Andy.Tui.Core`
   - `Andy.Tui.Compose`
   - `Andy.Tui.Style`
@@ -48,6 +49,7 @@ A modern, reactive TUI framework for .NET 8 with declarative components, reactiv
   - `Andy.Tui.Animations`
   - `Andy.Tui.Virtualization`
   - `Andy.Tui.Widgets`
+  - `Andy.Tui.CliWidgets`
   - `Andy.Tui.Observability`
 - `tests/` — xUnit test projects (non-packable)
 - `docs/` — design, roadmap, phases, testing, perf plans
@@ -101,7 +103,6 @@ dotnet nuget push ./nupkg/Andy.Tui.*.nupkg -k <NUGET_API_KEY> -s https://api.nug
 
 ## Development workflow
 - Format: `dotnet format`
-- Install pre-commit hooks: `./scripts/setup-git-hooks.sh` (macOS/Linux)
 - Tests must accompany code changes to `src/`
 - Run tests before committing significant changes: `dotnet test`
 - Generate coverage for meaningful refactors/features

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,16 +119,22 @@ Implement `IBackend` to support new output targets (e.g., HTML, GUI frameworks).
 
 ```
 src/
+├── Andy.Tui/                # Umbrella meta-package
 ├── Andy.Tui.Core/           # Reactive system
+├── Andy.Tui.Compose/        # Composition / component tree
 ├── Andy.Tui.Style/          # CSS and styling
 ├── Andy.Tui.Layout/         # Layout engine
 ├── Andy.Tui.Text/           # Text processing
 ├── Andy.Tui.Widgets/        # Widget library
+├── Andy.Tui.CliWidgets/     # CLI-focused widgets
 ├── Andy.Tui.DisplayList/    # Rendering commands
 ├── Andy.Tui.Compositor/     # Layer composition
 ├── Andy.Tui.Backend.Terminal/ # Terminal output
+├── Andy.Tui.Backend.Web/    # Web output backend
+├── Andy.Tui.Backend.Native/ # Native output backend
 ├── Andy.Tui.Input/          # Input handling
 ├── Andy.Tui.Animations/     # Animation system
+├── Andy.Tui.Virtualization/ # List/table virtualization
 └── Andy.Tui.Observability/  # Logging/debugging
 ```
 
@@ -142,8 +148,6 @@ src/
 
 ## Future Roadmap
 
-- **Web Backend**: Render to HTML/Canvas
-- **Native Backend**: Direct GUI framework integration
 - **Accessibility**: Screen reader support
 - **Theming**: Comprehensive theme system
 - **Hot Reload**: Live UI updates during development

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -119,7 +119,6 @@ container.AddChild(button);
 
 1. Explore the [Widget Catalog](WIDGETS.md) for available components
 2. Learn about [Architecture](ARCHITECTURE.md) for deeper understanding
-3. Check [API Reference](API_REFERENCE.md) for detailed documentation
 
 ## Important Notes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,10 +60,6 @@ var button = new Button { Label = "Increment" };
 button.Clicked += () => counter.Value++;
 ```
 
-## Contributing
-
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
-
 ## License
 
 Apache-2.0 License. See [LICENSE](../LICENSE) for details.


### PR DESCRIPTION
## Summary

Refresh stale markdown content:

- README.md: add missing `Andy.Tui` (umbrella) and `Andy.Tui.CliWidgets` projects to repository structure list; remove dead reference to `./scripts/setup-git-hooks.sh` (no scripts directory).
- docs/ARCHITECTURE.md: directory structure tree updated to include `Andy.Tui`, `Andy.Tui.Compose`, `Andy.Tui.CliWidgets`, `Andy.Tui.Backend.Web`, `Andy.Tui.Backend.Native`, `Andy.Tui.Virtualization`; remove Web/Native backends from "Future Roadmap" since they already exist in `src/`.
- docs/GETTING_STARTED.md: drop link to non-existent `API_REFERENCE.md`.
- docs/README.md: drop link to non-existent root `CONTRIBUTING.md`.

## Test plan

- [ ] Visual review of README and docs rendering