### PR TITLE
Reaction-Diffusion, more themes, Emoji Showcase demo, standalone screensaver

### DIFF
--- a/examples/Andy.Tui.Examples/Demos/CellularAutomatonDemo.cs
+++ b/examples/Andy.Tui.Examples/Demos/CellularAutomatonDemo.cs
@@ -30,7 +30,7 @@ namespace Andy.Tui.Examples.Demos;
 /// </summary>
 public static class CellularAutomatonDemo
 {
-    private enum Kind { Cyclic, BriansBrain, LifeFamily, ForestFire, Greenberg, LangtonAnt, Elementary }
+    private enum Kind { Cyclic, BriansBrain, LifeFamily, ForestFire, Greenberg, LangtonAnt, Elementary, ReactionDiffusion }
 
     private sealed class Rule
     {
@@ -68,6 +68,7 @@ public static class CellularAutomatonDemo
         Rule.Elem("Rule 90 (Sierpinski)", 90),
         Rule.Elem("Rule 110", 110),
         Rule.Elem("Rule 184 (traffic)", 184),
+        Rule.Simple("Reaction-Diffusion", Kind.ReactionDiffusion),
     };
 
     private sealed class GlyphTheme
@@ -92,6 +93,11 @@ public static class CellularAutomatonDemo
         new GlyphTheme("Birds", 2, "🪶", "🐦", "🐧", "🦆", "🦢", "🦅", "🦉", "🦜", "🐓"),
         new GlyphTheme("Construction", 2, "🚧", "🧱", "🔩", "🔧", "🔨", "🚧", "🚜", "🏭", "🪨"),
         new GlyphTheme("Computers", 2, "🔌", "💾", "💻", "💿", "📀", "🔌", "🔋", "📡", "📟"),
+        new GlyphTheme("Moon", 2, "🌝", "🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"),
+        new GlyphTheme("Sea", 2, "🦈", "🐟", "🐠", "🐡", "🦑", "🐙", "🦀", "🐚", "🐳"),
+        new GlyphTheme("Food", 2, "🍒", "🍎", "🍊", "🍋", "🍏", "🍐", "🍓", "🫐", "🍇"),
+        new GlyphTheme("Bugs", 2, "🐝", "🐛", "🐜", "🐝", "🦋", "🐞", "🦗", "🦟", "🐌"),
+        new GlyphTheme("Weather", 1, "✦", "·", "☁", "☂", "☃", "❄", "☀", "★", "☄"),
     };
 
     private sealed class LifePattern
@@ -136,6 +142,7 @@ public static class CellularAutomatonDemo
             "..OOO...OOO..",
         }, true, 0),
         new LifePattern("Glider Fleet", new[] { ".O.", "..O", "OOO" }, false, 14),
+        new LifePattern("Spaceships", new[] { ".OOOO", "O...O", "....O", "O..O." }, false, 8),
         new LifePattern("Acorn", new[] { ".O.....", "...O...", "OO..OOO" }, false, 3),
         new LifePattern("R-pentomino", new[] { ".OO", "OO.", ".O." }, false, 4),
     };
@@ -202,7 +209,7 @@ public static class CellularAutomatonDemo
         };
     }
 
-    public static async Task Run((int Width, int Height) viewport, TerminalCapabilities caps)
+    public static async Task Run((int Width, int Height) viewport, TerminalCapabilities caps, bool screensaver = false)
     {
         var scheduler = new Andy.Tui.Core.FrameScheduler();
         var hud = new Andy.Tui.Observability.HudOverlay { Enabled = false };
@@ -225,11 +232,13 @@ public static class CellularAutomatonDemo
         int gw = Math.Max(1, W / cellW), gh = Math.Max(1, H);
         int[] grid = new int[gw * gh];
         int[] next = new int[gw * gh];
+        // Reaction-Diffusion (Gray-Scott) chemical fields.
+        float[] rdU = new float[gw * gh], rdV = new float[gw * gh], rdU2 = new float[gw * gh], rdV2 = new float[gw * gh];
         var ants = new List<(int x, int y, int dir)>();
         int gen = 0; // counter for Langton trails / elementary generations
 
         bool paused = false;
-        bool showFooter = true;
+        bool showFooter = !screensaver;
         bool autoRotate = true;
         int stepDelayMs = 70;
 
@@ -310,6 +319,20 @@ public static class CellularAutomatonDemo
                     gen = 0;
                     grid[(gh - 1) * gw + gw / 2] = ++gen; // single seed on the bottom row
                     break;
+                case Kind.ReactionDiffusion:
+                    for (int i = 0; i < rdU.Length; i++) { rdU[i] = 1f; rdV[i] = 0f; }
+                    int blobs = grid.Length / 400 + 8;
+                    for (int bI = 0; bI < blobs; bI++)
+                    {
+                        int cx = rng.Next(gw), cy = rng.Next(gh);
+                        for (int dy = -2; dy <= 2; dy++)
+                            for (int dx = -2; dx <= 2; dx++)
+                            {
+                                int j = ((cy + dy + gh) % gh) * gw + (cx + dx + gw) % gw;
+                                rdU[j] = 0.5f; rdV[j] = 0.9f;
+                            }
+                    }
+                    break;
             }
             stagnantSteps = 0;
             lastPop = -1;
@@ -322,6 +345,8 @@ public static class CellularAutomatonDemo
             gh = Math.Max(1, H);
             grid = new int[gw * gh];
             next = new int[gw * gh];
+            rdU = new float[gw * gh]; rdV = new float[gw * gh];
+            rdU2 = new float[gw * gh]; rdV2 = new float[gw * gh];
             Seed();
             dirty = true;
         }
@@ -515,6 +540,34 @@ public static class CellularAutomatonDemo
                     if (on == 0) Seed();
                     return; // mutates grid in place
                 }
+
+                case Kind.ReactionDiffusion:
+                {
+                    // Gray-Scott. "Mitosis" params keep dividing — never settles.
+                    const float Du = 0.16f, Dv = 0.08f, F = 0.0367f, k = 0.0649f;
+                    for (int iter = 0; iter < 8; iter++)
+                    {
+                        for (int y = 0; y < gh; y++)
+                        {
+                            int ym = ((y - 1 + gh) % gh) * gw, yp = ((y + 1) % gh) * gw, y0 = y * gw;
+                            for (int x = 0; x < gw; x++)
+                            {
+                                int xm = (x - 1 + gw) % gw, xp = (x + 1) % gw;
+                                float uu = rdU[y0 + x], vv = rdV[y0 + x];
+                                float lapU = (rdU[y0 + xm] + rdU[y0 + xp] + rdU[ym + x] + rdU[yp + x]) * 0.2f
+                                           + (rdU[ym + xm] + rdU[ym + xp] + rdU[yp + xm] + rdU[yp + xp]) * 0.05f - uu;
+                                float lapV = (rdV[y0 + xm] + rdV[y0 + xp] + rdV[ym + x] + rdV[yp + x]) * 0.2f
+                                           + (rdV[ym + xm] + rdV[ym + xp] + rdV[yp + xm] + rdV[yp + xp]) * 0.05f - vv;
+                                float uvv = uu * vv * vv;
+                                rdU2[y0 + x] = uu + (Du * lapU - uvv + F * (1f - uu));
+                                rdV2[y0 + x] = vv + (Dv * lapV + uvv - (F + k) * vv);
+                            }
+                        }
+                        var tu = rdU; rdU = rdU2; rdU2 = tu;
+                        var tv = rdV; rdV = rdV2; rdV2 = tv;
+                    }
+                    return; // operates on float fields, not the int grid
+                }
             }
 
             var tmp = grid; grid = next; next = tmp;
@@ -585,11 +638,19 @@ public static class CellularAutomatonDemo
             var fgs = new DL.Rgb24[gw];
             var sb = new StringBuilder();
 
+            int rampLen = GlyphThemes[themeIndex].Ramp.Length;
             for (int cy = 0; cy < gh; cy++)
             {
                 for (int cx = 0; cx < gw; cx++)
                 {
-                    var (g, t) = CellVisual(grid[cy * gw + cx], rot);
+                    string? g; double t;
+                    if (kind == Kind.ReactionDiffusion)
+                    {
+                        float vv = rdV[cy * gw + cx];
+                        if (vv < 0.12f) { g = null; t = 0.0; }
+                        else { t = Math.Clamp(vv * 2.0, 0.0, 1.0); g = Ramp((int)(t * (rampLen - 1))); }
+                    }
+                    else (g, t) = CellVisual(grid[cy * gw + cx], rot);
                     glyphs[cx] = g;
                     fgs[cx] = g is null ? default : ColorAt(t);
                 }
@@ -667,6 +728,8 @@ public static class CellularAutomatonDemo
                 {
                     var k = Console.ReadKey(true);
                     if (k.Key == ConsoleKey.Escape) { running = false; break; }
+                    // In standalone screensaver mode, any key wakes/exits.
+                    if (screensaver) { running = false; break; }
                     char c = char.ToLowerInvariant(k.KeyChar);
                     if (k.Key == ConsoleKey.Spacebar || c == ' ') { paused = !paused; dirty = true; }
                     else if (c == 'q') { running = false; break; }

--- a/examples/Andy.Tui.Examples/Demos/EmojiShowcaseDemo.cs
+++ b/examples/Andy.Tui.Examples/Demos/EmojiShowcaseDemo.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Tui.Backend.Terminal;
+using Andy.Tui.Examples;
+using DL = Andy.Tui.DisplayList;
+
+namespace Andy.Tui.Examples.Demos;
+
+/// <summary>
+/// A gallery of the emoji glyph sets used by the cellular-automaton themes. Doubles as
+/// a live demonstration of the compositor's wide-glyph (surrogate-pair / double-width)
+/// rendering: every row is a single TextRun of double-width emoji and stays aligned.
+/// A rainbow sweep animates the title and a highlight marches down the categories.
+/// </summary>
+public static class EmojiShowcaseDemo
+{
+    private static readonly (string Name, string Glyphs)[] Categories =
+    {
+        ("Forest", "🌱 🌿 🍀 🌾 🌳 🌲 🎋 🪴 🌵 🍂 🍃 🍄"),
+        ("Plants", "🌷 🌸 🌹 🌺 🌻 🌼 💐 🪷 🌾 🪻 🌰 🥀"),
+        ("Farm", "🐔 🐤 🐣 🐓 🐑 🐐 🐖 🐄 🐴 🐮 🦃 🐕 🐈 🐇"),
+        ("Wild", "🦊 🐺 🦌 🐻 🦁 🐘 🦏 🐅 🐆 🦓 🦒 🦛 🐊 🦔"),
+        ("Birds", "🐦 🐧 🦆 🦢 🦅 🦉 🦜 🐓 🦃 🦩 🪿 🐔"),
+        ("Sea", "🐟 🐠 🐡 🦑 🐙 🦀 🐚 🐳 🐬 🦈 🐋 🦐 🦞"),
+        ("Bugs", "🐛 🐜 🐝 🦋 🐞 🦗 🦟 🐌 🪲 🪳 🦂 🪰"),
+        ("Food", "🍎 🍊 🍋 🍏 🍐 🍓 🫐 🍇 🍉 🍑 🍒 🥝 🥥"),
+        ("Space", "🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 🌝 🌚 🌟 🪐 🌌"),
+        ("Construction", "🧱 🔩 🔧 🔨 🚧 🚜 🏭 🪨 🧰 🪚 🛞 🚂"),
+        ("Computers", "💾 💻 💿 📀 🔌 🔋 📡 📟 📱 📺 🎮 🧮 🔭"),
+        ("Faces", "😀 😃 😄 😁 😆 😅 😂 🙂 😉 😊 😍 😎 🤩 🥳"),
+    };
+
+    public static async Task Run((int Width, int Height) viewport, TerminalCapabilities caps)
+    {
+        var scheduler = new Andy.Tui.Core.FrameScheduler();
+        var hud = new Andy.Tui.Observability.HudOverlay { Enabled = false };
+        scheduler.SetMetricsSink(hud);
+        var pty = new StdoutPty();
+
+        long startMs = Environment.TickCount64;
+
+        Console.Write("\u001b[?1049h\u001b[?25l\u001b[?7l");
+        try
+        {
+            bool running = true;
+            while (running)
+            {
+                viewport = TerminalHelpers.PollResize(viewport, scheduler);
+                while (Console.KeyAvailable)
+                {
+                    var k = Console.ReadKey(true);
+                    if (k.Key == ConsoleKey.Escape || k.Key == ConsoleKey.Q) { running = false; break; }
+                    if (k.Key == ConsoleKey.F2) hud.Enabled = !hud.Enabled;
+                }
+                if (!running) break;
+
+                int W = viewport.Width, H = viewport.Height;
+                long t = Environment.TickCount64 - startMs;
+
+                var b = new DL.DisplayListBuilder();
+                b.PushClip(new DL.ClipPush(0, 0, W, H));
+                b.DrawRect(new DL.Rect(0, 0, W, H, new DL.Rgb24(0, 0, 0)));
+
+                // Rainbow-swept title.
+                string title = "Emoji Showcase — wide-glyph rendering";
+                double sweep = t / 30.0;
+                for (int i = 0; i < title.Length && 2 + i < W; i++)
+                    b.DrawText(new DL.TextRun(2 + i, 1, title[i].ToString(),
+                        HsvToRgb((i * 9 + sweep) % 360.0, 0.7, 1.0), null, DL.CellAttrFlags.Bold));
+
+                int highlight = (int)((t / 600) % Categories.Length);
+                int labelW = 14;
+                for (int ci = 0; ci < Categories.Length; ci++)
+                {
+                    int y = 3 + ci;
+                    if (y >= H - 1) break;
+                    var (name, glyphs) = Categories[ci];
+                    bool hot = ci == highlight;
+                    var labelColor = hot ? new DL.Rgb24(255, 240, 150) : new DL.Rgb24(150, 160, 180);
+                    if (hot) b.DrawText(new DL.TextRun(0, y, "▶", new DL.Rgb24(255, 240, 150), null, DL.CellAttrFlags.Bold));
+                    b.DrawText(new DL.TextRun(2, y, name, labelColor, null, hot ? DL.CellAttrFlags.Bold : DL.CellAttrFlags.None));
+                    // Emoji render with their own colors; a single TextRun stays aligned.
+                    b.DrawText(new DL.TextRun(2 + labelW, y, glyphs, new DL.Rgb24(230, 230, 230), null, DL.CellAttrFlags.None));
+                }
+
+                string footer = " ESC/Q return · F2 HUD · emoji themes also drive the Cellular Automaton (menu 67) ";
+                if (footer.Length > W) footer = footer.Substring(0, W);
+                b.DrawRect(new DL.Rect(0, H - 1, W, 1, new DL.Rgb24(12, 12, 18)));
+                b.DrawText(new DL.TextRun(0, H - 1, footer, new DL.Rgb24(160, 160, 175), null, DL.CellAttrFlags.None));
+                b.Pop();
+
+                var baseDl = b.Build();
+                var overlay = new DL.DisplayListBuilder();
+                hud.ViewportCols = W; hud.ViewportRows = H;
+                hud.Contribute(baseDl, overlay);
+                await scheduler.RenderOnceAsync(Combine(baseDl, overlay.Build()), viewport, caps, pty, CancellationToken.None);
+                await Task.Delay(33);
+            }
+        }
+        finally
+        {
+            Console.Write("\u001b[?7h\u001b[?25h\u001b[?1049l");
+        }
+    }
+
+    private static DL.Rgb24 HsvToRgb(double h, double s, double v)
+    {
+        h = ((h % 360.0) + 360.0) % 360.0;
+        double c = v * s;
+        double x = c * (1 - Math.Abs((h / 60.0) % 2 - 1));
+        double m = v - c;
+        double r, g, b;
+        if (h < 60) { r = c; g = x; b = 0; }
+        else if (h < 120) { r = x; g = c; b = 0; }
+        else if (h < 180) { r = 0; g = c; b = x; }
+        else if (h < 240) { r = 0; g = x; b = c; }
+        else if (h < 300) { r = x; g = 0; b = c; }
+        else { r = c; g = 0; b = x; }
+        return new DL.Rgb24(
+            (byte)Math.Clamp((r + m) * 255.0, 0, 255),
+            (byte)Math.Clamp((g + m) * 255.0, 0, 255),
+            (byte)Math.Clamp((b + m) * 255.0, 0, 255));
+    }
+
+    private static DL.DisplayList Combine(DL.DisplayList a, DL.DisplayList b)
+    {
+        var builder = new DL.DisplayListBuilder();
+        void Append(DL.DisplayList dl)
+        {
+            foreach (var op in dl.Ops)
+            {
+                switch (op)
+                {
+                    case DL.Rect r: builder.DrawRect(r); break;
+                    case DL.Border br: builder.DrawBorder(br); break;
+                    case DL.TextRun tr: builder.DrawText(tr); break;
+                    case DL.ClipPush cp: builder.PushClip(cp); break;
+                    case DL.LayerPush lp: builder.PushLayer(lp); break;
+                    case DL.Pop: builder.Pop(); break;
+                }
+            }
+        }
+        Append(a);
+        Append(b);
+        return builder.Build();
+    }
+}

--- a/examples/Andy.Tui.Examples/Program.cs
+++ b/examples/Andy.Tui.Examples/Program.cs
@@ -9,10 +9,25 @@ using Andy.Tui.DisplayList;
 
 class Program
 {
-    static async Task Main()
+    static async Task Main(string[] args)
     {
         var caps = CapabilityDetector.DetectFromEnvironment();
         var viewport = (Width: Console.WindowWidth, Height: Console.WindowHeight);
+
+        // Launch a demo directly (skip the menu), e.g. `dotnet run -- screensaver`.
+        var direct = args.Length > 0 ? args[0].Trim().ToLowerInvariant() : "";
+        switch (direct)
+        {
+            case "screensaver":
+            case "ca":
+            case "automaton":
+                await CellularAutomatonDemo.Run(viewport, caps, screensaver: true);
+                return;
+            case "emoji":
+                await EmojiShowcaseDemo.Run(viewport, caps);
+                return;
+        }
+
         await RunMainMenu(viewport, caps);
     }
 
@@ -245,7 +260,8 @@ class Program
                 "64) Hacker News Reader",
                 "65) Transparent Background",
                 "66) Themes Showcase (all themes)",
-                "67) Cellular Automaton (screensaver)"
+                "67) Cellular Automaton (screensaver)",
+                "68) Emoji Showcase"
             };
 
             // Two-column layout
@@ -336,6 +352,7 @@ class Program
                 case "65": await TransparentBackgroundDemo.Run(viewport, caps); break;
                 case "66": await ThemesShowcaseDemo.Run(viewport, caps); break;
                 case "67": await CellularAutomatonDemo.Run(viewport, caps); break;
+                case "68": await EmojiShowcaseDemo.Run(viewport, caps); break;
             }
         }
     }


### PR DESCRIPTION
Continues #9 with more variations and a dedicated emoji demo.

## Cellular Automaton (menu 67)
- **Reaction-Diffusion** (Gray-Scott, mitosis params): organic spots that perpetually divide, rendered from float chemical fields — never settles, ideal for a screensaver.
- **More glyph themes** (`[`/`]`): Moon phases 🌑🌒🌓, Sea 🐟, Food 🍎, Bugs 🐛, Weather (BMP) — now 15 themes.
- **New Life seed** (`P`): Spaceships (LWSS).
- **Standalone screensaver entry**: `dotnet run --project examples/Andy.Tui.Examples -- screensaver` launches the automaton directly (no menu), footer hidden; **any key exits**.

## Emoji Showcase (new — menu 68, or `-- emoji`)
A gallery of every emoji glyph set, which also serves as a live demonstration of the wide-glyph rendering landed in #9: each category is a single double-width TextRun that stays aligned. Rainbow-swept title + a highlight that marches down the categories.

Builds clean; rendering/widgets tests from #9 remain green (no further core changes here).