### PR TITLE
Render inline code in a distinct color instead of underlining it

### DIFF
--- a/src/Andy.Tui.Widgets/MarkdownRenderer.cs
+++ b/src/Andy.Tui.Widgets/MarkdownRenderer.cs
@@ -18,11 +18,14 @@ namespace Andy.Tui.Widgets
         private DL.Rgb24 _h2Color = new DL.Rgb24(150,220,150);  // Green for H2
         private DL.Rgb24 _h3Color = new DL.Rgb24(255,180,100);  // Orange for H3
         private DL.Rgb24 _listColor = new DL.Rgb24(255,150,150); // Light red for list markers
+        private DL.Rgb24 _inlineCodeColor = new DL.Rgb24(220,180,120); // inline `code`
 
         public void SetText(string md) => _md = md ?? string.Empty;
         public void SetColors(DL.Rgb24 fg, DL.Rgb24 bg, DL.Rgb24 accent) { _fg = fg; _bg = bg; _accent = accent; }
         public void SetHeaderColors(DL.Rgb24 h1, DL.Rgb24 h2, DL.Rgb24 h3) { _h1Color = h1; _h2Color = h2; _h3Color = h3; }
         public void SetListColor(DL.Rgb24 listColor) { _listColor = listColor; }
+        /// <summary>Color used for inline `code` spans (a distinct color, never an underline).</summary>
+        public void SetInlineCodeColor(DL.Rgb24 c) { _inlineCodeColor = c; }
 
         private static readonly Regex Bold = new Regex(@"\*\*(.+?)\*\*", RegexOptions.Compiled);
         private static readonly Regex Italic = new Regex(@"\*(.+?)\*", RegexOptions.Compiled);
@@ -46,6 +49,7 @@ namespace Andy.Tui.Widgets
                 if (cy >= y + h) break;
                 string text = line;
                 DL.CellAttrFlags attrs = DL.CellAttrFlags.None;
+                bool codeMode = false; // inside an inline `code` span
                 var color = _fg;
                 int indent = 0;
                 string listMarker = "";
@@ -125,9 +129,9 @@ namespace Andy.Tui.Widgets
                     {
                         if (segmentCx >= x + w) break;
                         if (ch == '\u0001') { attrs ^= DL.CellAttrFlags.Bold; continue; }
-                        if (ch == '\u0002') { attrs ^= DL.CellAttrFlags.Underline; continue; }
-                        if (ch == '\u0003') { /* code */ attrs ^= DL.CellAttrFlags.Underline; continue; }
-                        b.DrawText(new DL.TextRun(segmentCx++, cy, ch.ToString(), color, _bg, attrs));
+                        if (ch == '\u0002') { /* italic: color, not underline */ continue; }
+                        if (ch == '\u0003') { codeMode = !codeMode; continue; }
+                        b.DrawText(new DL.TextRun(segmentCx++, cy, ch.ToString(), codeMode ? _inlineCodeColor : color, _bg, attrs));
                     }
                     
                     pos = segmentEnd;

--- a/tests/Andy.Tui.Widgets.Tests/MarkdownInlineCodeTests.cs
+++ b/tests/Andy.Tui.Widgets.Tests/MarkdownInlineCodeTests.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using Andy.Tui.Widgets;
+using DL = Andy.Tui.DisplayList;
+using L = Andy.Tui.Layout;
+using Xunit;
+
+namespace Andy.Tui.Widgets.Tests;
+
+public class MarkdownInlineCodeTests
+{
+    private static DL.DisplayList Render(string md, DL.Rgb24 codeColor)
+    {
+        var r = new MarkdownRenderer();
+        r.SetColors(new DL.Rgb24(220, 220, 220), new DL.Rgb24(0, 0, 0), new DL.Rgb24(200, 200, 80));
+        r.SetInlineCodeColor(codeColor);
+        r.SetText(md);
+        var b = new DL.DisplayListBuilder();
+        r.Render(new L.Rect(0, 0, 60, 4), new DL.DisplayListBuilder().Build(), b);
+        return b.Build();
+    }
+
+    [Fact]
+    public void InlineCode_IsDrawnInTheCodeColor_WithoutUnderline()
+    {
+        var codeColor = new DL.Rgb24(11, 22, 33);
+        var dl = Render("call `Method` now", codeColor);
+
+        var runs = dl.Ops.OfType<DL.TextRun>().ToList();
+        // The characters of the inline code get the code color...
+        var codeChars = runs.Where(t => t.Fg.HasValue && t.Fg.Value.Equals(codeColor))
+                            .OrderBy(t => t.X).Select(t => t.Content);
+        Assert.Equal("Method", string.Concat(codeChars));
+
+        // ...and nothing is underlined.
+        Assert.DoesNotContain(runs, t => (t.Attrs & DL.CellAttrFlags.Underline) != 0);
+    }
+
+    [Fact]
+    public void Italics_AreNotUnderlined()
+    {
+        var dl = Render("this is *emphasis* text", new DL.Rgb24(11, 22, 33));
+        var runs = dl.Ops.OfType<DL.TextRun>().ToList();
+        Assert.DoesNotContain(runs, t => (t.Attrs & DL.CellAttrFlags.Underline) != 0);
+        // The emphasized word is still rendered (its markers are stripped).
+        var text = string.Concat(runs.OrderBy(t => t.X).Select(t => t.Content));
+        Assert.Contains("emphasis", text);
+    }
+}


### PR DESCRIPTION
## Summary
The markdown renderer underlined inline `code` spans and *italic* text. This draws inline code in a dedicated, settable color (no underline) and stops underlining italics; bold is unchanged.

- `SetInlineCodeColor(Rgb24)` lets callers (e.g. andy-cli) pass a theme color.
- The inline-code marker switches the draw color instead of toggling underline.
- Tests: inline code is drawn in the code color with no underline anywhere.

## Why
andy-cli surfaces method/class names in backticks; they were rendered underlined. After this publishes, andy-cli will call `SetInlineCodeColor(theme.SyntaxType)` so inline code matches the themed code-block highlighting.

Needs a review approval to merge + publish (branch protection). Once a new `Andy.Tui` prerelease is on NuGet I'll bump andy-cli and wire it up.